### PR TITLE
manifestFilePattern becomes manifestConfig

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,13 @@
       "request": "launch",
       "protocol": "inspector",
       "program": "${file}",
-      "runtimeVersion": "13.6.0",
+      "runtimeArgs": [
+        "--unhandled-rejections=strict",
+        "--experimental-json-modules",
+        "--experimental-top-level-await",
+        // this is to disable experimental warning
+        "--no-warnings"
+      ],
       "autoAttachChildProcesses": true,
       "sourceMaps": true,
       "smartStep": true,

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,10 +4,10 @@
   - [logLevel](#loglevel)
   - [projectDirectoryUrl](#projectDirectoryUrl)
   - [trackingConfig](#trackingConfig)
+  - [manifestConfig](#manifestConfig)
   - [installCommand](#installCommand)
   - [buildCommand](#buildCommand)
   - [transformations](#transformations)
-  - [manifestFilePattern](#manifestFilePattern)
   - [commentSections](#commentSections)
   - [runLink](#runLink)
   - [formatSize](#formatSize)
@@ -89,6 +89,24 @@ And the generated comment will have two expandable section.
   Analysis for files matching dist group
 </details>
 
+## manifestConfig
+
+Manifest where introduced by webpack in https://github.com/danethurber/webpack-manifest-plugin. There is the equivalent for rollup at https://github.com/shuizhongyueming/rollup-plugin-output-manifest.
+
+The concept is to be able to remap generated file like `file.4798774987w97er984798.js` back to `file.js`.
+
+Without this, comparison of directories accross branches would consider generated files as always new because of their dynamic names.
+
+`manifestConfig` parameter is an object controlling if a manifest json file will be taken into account when generating snapshot. The parameter also control the name of the manifest file. This parameter is optional with a default configured to handle any `manifest.json` file inside a `dist` directory as a manifest json file. It translates to the following value:
+
+```js
+const manifestConfig = {
+  "./dist/**/manifest.json": true,
+}
+```
+
+This parameter reuse [trackingConfig](#trackingConfig) type and `specifierMetaMap` as documented in https://github.com/jsenv/jsenv-url-meta#normalizespecifiermetamap.
+
 ## installCommand
 
 `installCommand` parameter is a string representing the command to run in order to install things just after a switching to a git branch. This parameter is optional with a default value of `"npm install"`.
@@ -142,16 +160,6 @@ const transformations = {
   trim: (buffer) => String(buffer).trim(),
 }
 ```
-
-## manifestFilePattern
-
-`manifestFilePattern` parameter is a string controlling if a manifest json file will be taken into account when generating snapshot. The parameter also control the name of the manifest file. This parameter is optional with a default value of `./**/manifest.json`.
-
-Manifest where introduced by webpack in https://github.com/danethurber/webpack-manifest-plugin. There is the equivalent for rollup at https://github.com/shuizhongyueming/rollup-plugin-output-manifest.
-
-The concept is to be able to remap generated file like `file.4798774987w97er984798.js` back to `file.js`.
-
-Without this, comparison of directories accross branches would consider generated files as always new because of their dynamic names.
 
 ## commentSections
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsenv/file-size-impact",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "Add files size impact into pull requests.",
   "license": "MIT",
   "repository": {
@@ -27,14 +27,14 @@
     "/index.js"
   ],
   "scripts": {
-    "test": "node --no-warnings ./script/test/test.js",
+    "test": "node ./script/test/test.js",
     "test-with-coverage": "npm run test -- --coverage",
     "eslint-check": "node ./node_modules/eslint/bin/eslint.js .",
-    "prettier-format": "node --no-warnings ./script/prettier-format/prettier-format.js",
+    "prettier-format": "node ./script/prettier-format/prettier-format.js",
     "prettier-format-stage": "npm run prettier-format -- --staged",
     "prettier-check": "npm run prettier-format -- --dry-run",
     "upload-coverage": "node ./script/upload-coverage/upload-coverage.js",
-    "generate-comment-example": "node --no-warnings ./docs/generate-comment-example.js",
+    "generate-comment-example": "node ./docs/generate-comment-example.js",
     "generate-commonjs-bundle": "node ./script/generate-commonjs-bundle/generate-commonjs-bundle.js",
     "generate-import-map": "node ./script/generate-import-map/generate-import-map.js",
     "dist": "npm run generate-commonjs-bundle",

--- a/src/internal/generateSnapshot.js
+++ b/src/internal/generateSnapshot.js
@@ -15,7 +15,7 @@ export const generateSnapshot = async ({
   logLevel,
   projectDirectoryUrl,
   trackingConfig,
-  manifestFilePattern,
+  manifestConfig,
   transformations,
 }) => {
   const logger = createLogger({ logLevel })
@@ -36,15 +36,11 @@ export const generateSnapshot = async ({
   await Promise.all(
     trackingNames.map(async (trackingName) => {
       const tracking = trackingConfig[trackingName]
-      const specifierMetaMap = metaMapToSpecifierMetaMap({
-        track: tracking,
-        ...(manifestFilePattern ? { manifest: { [manifestFilePattern]: true } } : {}),
-      })
 
-      const trackingResult = await applyTracking({
+      const trackingResult = await applyTracking(tracking, {
         logger,
         projectDirectoryUrl,
-        specifierMetaMap,
+        manifestConfig,
         transformations,
       })
       snapshot[trackingName] = trackingResult
@@ -57,12 +53,15 @@ export const generateSnapshot = async ({
   return snapshot
 }
 
-const applyTracking = async ({
-  logger,
-  projectDirectoryUrl,
-  specifierMetaMap,
-  transformations,
-}) => {
+const applyTracking = async (
+  tracking,
+  { logger, projectDirectoryUrl, manifestConfig, transformations },
+) => {
+  const specifierMetaMap = metaMapToSpecifierMetaMap({
+    track: tracking,
+    ...(manifestConfig ? { manifest: manifestConfig } : {}),
+  })
+
   const manifestMap = {}
   const fileMap = {}
   let files

--- a/src/reportFileSizeImpact.js
+++ b/src/reportFileSizeImpact.js
@@ -31,7 +31,9 @@ export const reportFileSizeImpact = async ({
   buildCommand = "npm run-script build",
 
   trackingConfig = jsenvTrackingConfig,
-  manifestFilePattern = "./**/manifest.json",
+  manifestConfig = {
+    "./dist/**/manifest.json": true,
+  },
   transformations = { none: noneTransform },
 
   formatSize = jsenvFormatSize,
@@ -184,9 +186,7 @@ ${renderGeneratedBy({ runLink })}`
 
       let baseSnapshot
       try {
-        await execCommandInProjectDirectory(
-          `git fetch --no-tags --prune --depth=1 origin ${pullRequestBase}`,
-        )
+        await execCommandInProjectDirectory(`git fetch --no-tags --prune origin ${pullRequestBase}`)
         await execCommandInProjectDirectory(`git checkout origin/${pullRequestBase}`)
         await execCommandInProjectDirectory(installCommand)
         await execCommandInProjectDirectory(buildCommand)
@@ -195,7 +195,7 @@ ${renderGeneratedBy({ runLink })}`
           logLevel,
           projectDirectoryUrl,
           trackingConfig,
-          manifestFilePattern,
+          manifestConfig,
           transformations,
         })
       } catch (error) {
@@ -242,7 +242,7 @@ ${renderGeneratedBy({ runLink })}`
           logLevel,
           projectDirectoryUrl,
           trackingConfig,
-          manifestFilePattern,
+          manifestConfig,
           transformations,
         })
       } catch (error) {

--- a/test/generateSnapshotFile/generateSnapshot.test.js
+++ b/test/generateSnapshotFile/generateSnapshot.test.js
@@ -55,7 +55,9 @@ const tempDirectoryUrl = resolveUrl("./temp/", import.meta.url)
       },
     },
     transformations,
-    manifestFilePattern: "./**/manifest.json",
+    manifestConfig: {
+      "./**/manifest.json": true,
+    },
   })
   const expected = {
     dist: {


### PR DESCRIPTION
allow to better control on which file are manifest.
Did that mostly to prevent crawling the entire directory searching for a manifest file.